### PR TITLE
add streaming api for parquet files

### DIFF
--- a/packages/parquet-reader/examples/stream-from-downloads.ts
+++ b/packages/parquet-reader/examples/stream-from-downloads.ts
@@ -1,0 +1,5 @@
+import { streamParquet } from "../src/index.js";
+
+for await (const row of streamParquet(process.argv[2]!)) {
+  console.log(row);
+}

--- a/packages/parquet-reader/examples/stream-from-url.ts
+++ b/packages/parquet-reader/examples/stream-from-url.ts
@@ -1,0 +1,11 @@
+import { streamParquet } from "../src/index.js";
+
+const url =
+  process.argv[2] ??
+  "https://huggingface.co/datasets/open-llm-leaderboard/contents/resolve/main/data/train-00000-of-00001.parquet";
+
+let count = 0;
+for await (const row of streamParquet(url)) {
+  console.log(row);
+  if (++count >= 5) break;
+}

--- a/packages/parquet-reader/src/streaming.ts
+++ b/packages/parquet-reader/src/streaming.ts
@@ -1,0 +1,129 @@
+import type { AsyncBuffer } from "hyparquet";
+import { parquetMetadataAsync, parquetReadObjects } from "hyparquet";
+import { compressors } from "hyparquet-compressors";
+
+import type { ParquetRow } from "./types.js";
+
+export type StreamOptions = {
+  columns?: string[];
+  batchSize?: number;
+  signal?: AbortSignal;
+};
+
+export type PageOptions = {
+  page: number;
+  pageSize: number;
+  columns?: string[];
+};
+
+export type PageResult = {
+  rows: ParquetRow[];
+  hasMore: boolean;
+  totalRows?: number;
+};
+
+type ParquetFile = AsyncBuffer | ArrayBuffer;
+
+const DEFAULT_CHUNK_SIZE = 1000;
+
+/**
+ * Stream rows from a parquet file.
+ *
+ * By default, yields individual rows. Set `batchSize` to yield arrays of rows.
+ *
+ * @example
+ * // Stream rows one at a time
+ * for await (const row of streamRows(file)) {
+ *   console.log(row);
+ * }
+ *
+ * @example
+ * // Stream in batches
+ * for await (const batch of streamRows(file, { batchSize: 100 })) {
+ *   console.log(batch.length);
+ * }
+ */
+export async function* streamRows(
+  file: ParquetFile,
+  options?: StreamOptions,
+): AsyncGenerator<ParquetRow | ParquetRow[]> {
+  const { columns, batchSize, signal } = options ?? {};
+
+  const metadata = await parquetMetadataAsync(file);
+  const totalRows = Number(metadata.num_rows);
+
+  if (totalRows === 0) {
+    return;
+  }
+
+  const chunkSize = batchSize ?? DEFAULT_CHUNK_SIZE;
+  let currentRow = 0;
+
+  while (currentRow < totalRows) {
+    if (signal?.aborted) {
+      return;
+    }
+
+    const rowEnd = Math.min(currentRow + chunkSize, totalRows);
+    const rows = (await parquetReadObjects({
+      file,
+      columns,
+      rowStart: currentRow,
+      rowEnd,
+      compressors,
+      rowFormat: "object",
+    })) as ParquetRow[];
+
+    if (batchSize) {
+      yield rows;
+    } else {
+      for (const row of rows) {
+        if (signal?.aborted) {
+          return;
+        }
+        yield row;
+      }
+    }
+
+    currentRow = rowEnd;
+  }
+}
+
+/**
+ * Read a specific page of rows from a parquet file.
+ *
+ * @example
+ * const { rows, hasMore, totalRows } = await readPage(file, { page: 0, pageSize: 100 });
+ */
+export async function readPage(file: ParquetFile, options: PageOptions): Promise<PageResult> {
+  const { page, pageSize, columns } = options;
+
+  if (page < 0 || pageSize <= 0) {
+    return { rows: [], hasMore: false, totalRows: 0 };
+  }
+
+  const metadata = await parquetMetadataAsync(file);
+  const totalRows = Number(metadata.num_rows);
+
+  const rowStart = page * pageSize;
+  const rowEnd = Math.min(rowStart + pageSize, totalRows);
+
+  if (rowStart >= totalRows) {
+    return { rows: [], hasMore: false, totalRows };
+  }
+
+  const rows = (await parquetReadObjects({
+    file,
+    columns,
+    rowStart,
+    rowEnd,
+    compressors,
+    rowFormat: "object",
+  })) as ParquetRow[];
+
+  return {
+    rows,
+    hasMore: rowEnd < totalRows,
+    totalRows,
+  };
+}


### PR DESCRIPTION
Add streaming capabilities to parquet-reader package.

- Streaming API: supports batching, column selection, and cancellation
- Page-based reading: query specific pages with metadata
- Two working examples: local files and remote URLs

```ts
import { streamParquet } from "@parquetlens/parquet-reader";

for await (const row of streamParquet("~/Downloads/data.parquet")) {
  console.log(row);
}
```